### PR TITLE
Nulleble for TestData

### DIFF
--- a/src/XUnit3Helper/Models/TestData.cs
+++ b/src/XUnit3Helper/Models/TestData.cs
@@ -26,77 +26,77 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     /// <summary>
     /// The eighth data value.
     /// </summary>
-    public TP8 P8 { get; init; }
+    public TP8? P8 { get; init; }
 
     /// <summary>
     /// The ninth data value.
     /// </summary>
-    public TP9 P9 { get; init; }
+    public TP9? P9 { get; init; }
 
     /// <summary>
     /// The tenth data value.
     /// </summary>
-    public TP10 P10 { get; init; }
+    public TP10? P10 { get; init; }
 
     /// <summary>
     /// The eleventh data value.
     /// </summary>
-    public TP11 P11 { get; init; }
+    public TP11? P11 { get; init; }
 
     /// <summary>
     /// The twelfth data value.
     /// </summary>
-    public TP12 P12 { get; init; }
+    public TP12? P12 { get; init; }
 
     /// <summary>
     /// The thirteenth data value.
     /// </summary>
-    public TP13 P13 { get; init; }
+    public TP13? P13 { get; init; }
 
     /// <summary>
     /// The fourteenth data value.
     /// </summary>
-    public TP14 P14 { get; init; }
+    public TP14? P14 { get; init; }
 
     /// <summary>
     /// The fifteenth data value.
     /// </summary>
-    public TP15 P15 { get; init; }
+    public TP15? P15 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -105,9 +105,9 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P11, P12, P13, P14, P15
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7, TP8, TP9, TP10,
-        TP11, TP12, TP13, TP14, TP15>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?, TP8?, TP9?, TP10?,
+        TP11?, TP12?, TP13?, TP14?, TP15?>(P1, P2, P3, P4, P5,
         P6, P7, P8, P9, P10,
         P11, P12, P13, P14, P15);
 }
@@ -137,72 +137,72 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     /// <summary>
     /// The eighth data value.
     /// </summary>
-    public TP8 P8 { get; init; }
+    public TP8? P8 { get; init; }
 
     /// <summary>
     /// The ninth data value.
     /// </summary>
-    public TP9 P9 { get; init; }
+    public TP9? P9 { get; init; }
 
     /// <summary>
     /// The tenth data value.
     /// </summary>
-    public TP10 P10 { get; init; }
+    public TP10? P10 { get; init; }
 
     /// <summary>
     /// The eleventh data value.
     /// </summary>
-    public TP11 P11 { get; init; }
+    public TP11? P11 { get; init; }
 
     /// <summary>
     /// The twelfth data value.
     /// </summary>
-    public TP12 P12 { get; init; }
+    public TP12? P12 { get; init; }
 
     /// <summary>
     /// The thirteenth data value.
     /// </summary>
-    public TP13 P13 { get; init; }
+    public TP13? P13 { get; init; }
 
     /// <summary>
     /// The fourteenth data value.
     /// </summary>
-    public TP14 P14 { get; init; }
+    public TP14? P14 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -211,9 +211,9 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P11, P12, P13, P14
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7, TP8, TP9, TP10,
-        TP11, TP12, TP13, TP14>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?, TP8?, TP9?, TP10?,
+        TP11?, TP12?, TP13?, TP14?>(P1, P2, P3, P4, P5,
         P6, P7, P8, P9, P10,
         P11, P12, P13, P14);
 }
@@ -242,67 +242,67 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     /// <summary>
     /// The eighth data value.
     /// </summary>
-    public TP8 P8 { get; init; }
+    public TP8? P8 { get; init; }
 
     /// <summary>
     /// The ninth data value.
     /// </summary>
-    public TP9 P9 { get; init; }
+    public TP9? P9 { get; init; }
 
     /// <summary>
     /// The tenth data value.
     /// </summary>
-    public TP10 P10 { get; init; }
+    public TP10? P10 { get; init; }
 
     /// <summary>
     /// The eleventh data value.
     /// </summary>
-    public TP11 P11 { get; init; }
+    public TP11? P11 { get; init; }
 
     /// <summary>
     /// The twelfth data value.
     /// </summary>
-    public TP12 P12 { get; init; }
+    public TP12? P12 { get; init; }
 
     /// <summary>
     /// The thirteenth data value.
     /// </summary>
-    public TP13 P13 { get; init; }
+    public TP13? P13 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -311,9 +311,9 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P11, P12, P13
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7, TP8, TP9, TP10,
-        TP11, TP12, TP13>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?, TP8?, TP9?, TP10?,
+        TP11?, TP12?, TP13?>(P1, P2, P3, P4, P5,
         P6, P7, P8, P9, P10,
         P11, P12, P13);
 }
@@ -341,62 +341,62 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     /// <summary>
     /// The eighth data value.
     /// </summary>
-    public TP8 P8 { get; init; }
+    public TP8? P8 { get; init; }
 
     /// <summary>
     /// The ninth data value.
     /// </summary>
-    public TP9 P9 { get; init; }
+    public TP9? P9 { get; init; }
 
     /// <summary>
     /// The tenth data value.
     /// </summary>
-    public TP10 P10 { get; init; }
+    public TP10? P10 { get; init; }
 
     /// <summary>
     /// The eleventh data value.
     /// </summary>
-    public TP11 P11 { get; init; }
+    public TP11? P11 { get; init; }
 
     /// <summary>
     /// The twelfth data value.
     /// </summary>
-    public TP12 P12 { get; init; }
+    public TP12? P12 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -405,9 +405,9 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P11, P12
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7, TP8, TP9, TP10,
-        TP11, TP12>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?, TP8?, TP9?, TP10?,
+        TP11?, TP12?>(P1, P2, P3, P4, P5,
         P6, P7, P8, P9, P10,
         P11, P12);
 }
@@ -434,57 +434,57 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     /// <summary>
     /// The eighth data value.
     /// </summary>
-    public TP8 P8 { get; init; }
+    public TP8? P8 { get; init; }
 
     /// <summary>
     /// The ninth data value.
     /// </summary>
-    public TP9 P9 { get; init; }
+    public TP9? P9 { get; init; }
 
     /// <summary>
     /// The tenth data value.
     /// </summary>
-    public TP10 P10 { get; init; }
+    public TP10? P10 { get; init; }
 
     /// <summary>
     /// The eleventh data value.
     /// </summary>
-    public TP11 P11 { get; init; }
+    public TP11? P11 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -493,9 +493,9 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P11
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7, TP8, TP9, TP10,
-        TP11>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?, TP8?, TP9?, TP10?,
+        TP11?>(P1, P2, P3, P4, P5,
         P6, P7, P8, P9, P10,
         P11);
 }
@@ -519,52 +519,52 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     /// <summary>
     /// The eighth data value.
     /// </summary>
-    public TP8 P8 { get; init; }
+    public TP8? P8 { get; init; }
 
     /// <summary>
     /// The ninth data value.
     /// </summary>
-    public TP9 P9 { get; init; }
+    public TP9? P9 { get; init; }
 
     /// <summary>
     /// The tenth data value.
     /// </summary>
-    public TP10 P10 { get; init; }
+    public TP10? P10 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -572,8 +572,8 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P6, P7, P8, P9, P10
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7, TP8, TP9, TP10>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?, TP8?, TP9?, TP10?>(P1, P2, P3, P4, P5,
         P6, P7, P8, P9, P10);
 }
 
@@ -596,47 +596,47 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     /// <summary>
     /// The eighth data value.
     /// </summary>
-    public TP8 P8 { get; init; }
+    public TP8? P8 { get; init; }
 
     /// <summary>
     /// The ninth data value.
     /// </summary>
-    public TP9 P9 { get; init; }
+    public TP9? P9 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -644,8 +644,8 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P6, P7, P8, P9
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7, TP8, TP9>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?, TP8?, TP9?>(P1, P2, P3, P4, P5,
         P6, P7, P8, P9);
 }
 
@@ -667,42 +667,42 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     /// <summary>
     /// The eighth data value.
     /// </summary>
-    public TP8 P8 { get; init; }
+    public TP8? P8 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -710,8 +710,8 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P6, P7, P8
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7, TP8>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?, TP8?>(P1, P2, P3, P4, P5,
         P6, P7, P8);
 }
 
@@ -732,37 +732,37 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     /// <summary>
     /// The seventh data value.
     /// </summary>
-    public TP7 P7 { get; init; }
+    public TP7? P7 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -770,8 +770,8 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P6, P7
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6, TP7>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?, TP7?>(P1, P2, P3, P4, P5,
         P6, P7);
 }
 
@@ -791,32 +791,32 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     /// <summary>
     /// The sixth data value.
     /// </summary>
-    public TP6 P6 { get; init; }
+    public TP6? P6 { get; init; }
 
     public override object?[] GetObjects() =>
     [
@@ -824,8 +824,8 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5,
         P6
     ];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5,
-        TP6>(P1, P2, P3, P4, P5,
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?,
+        TP6?>(P1, P2, P3, P4, P5,
         P6);
 }
 
@@ -843,31 +843,31 @@ public sealed class TestData<TP1, TP2, TP3, TP4, TP5>
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     /// <summary>
     /// The fifth data value.
     /// </summary>
-    public TP5 P5 { get; init; }
+    public TP5? P5 { get; init; }
 
     public override object?[] GetObjects() => [P1, P2, P3, P4, P5];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4, TP5>(P1, P2, P3, P4, P5);
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?, TP5?>(P1, P2, P3, P4, P5);
 }
 
 /// <summary>
@@ -883,26 +883,26 @@ public sealed class TestData<TP1, TP2, TP3, TP4>
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     /// <summary>
     /// The fourth data value.
     /// </summary>
-    public TP4 P4 { get; init; }
+    public TP4? P4 { get; init; }
 
     public override object?[] GetObjects() => [P1, P2, P3, P4];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3, TP4>(P1, P2, P3, P4);
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?, TP4?>(P1, P2, P3, P4);
 }
 
 /// <summary>
@@ -917,21 +917,21 @@ public sealed class TestData<TP1, TP2, TP3>
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     /// <summary>
     /// The third data value.
     /// </summary>
-    public TP3 P3 { get; init; }
+    public TP3? P3 { get; init; }
 
     public override object?[] GetObjects() => [P1, P2, P3];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2, TP3>(P1, P2, P3);
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?, TP3?>(P1, P2, P3);
 }
 
 /// <summary>
@@ -945,16 +945,16 @@ public sealed class TestData<TP1, TP2>
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     /// <summary>
     /// The second data value.
     /// </summary>
-    public TP2 P2 { get; init; }
+    public TP2? P2 { get; init; }
 
     public override object?[] GetObjects() => [P1, P2];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1, TP2>(P1, P2);
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?, TP2?>(P1, P2);
 }
 
 /// <summary>
@@ -967,11 +967,11 @@ public sealed class TestData<TP1>
     /// <summary>
     /// The first data value.
     /// </summary>
-    public TP1 P1 { get; init; }
+    public TP1? P1 { get; init; }
 
     public override object?[] GetObjects() => [P1];
 
-    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1>(P1);
+    public override ITheoryDataRow GetTheoryDataRow() => new TheoryDataRow<TP1?>(P1);
 }
 
 public abstract class BaseTestData

--- a/src/XUnit3Helper/PublicAPI.Unshipped.txt
+++ b/src/XUnit3Helper/PublicAPI.Unshipped.txt
@@ -33,7 +33,7 @@ override XUnit3Helper.Models.TestData<TP1, TP2>.GetObjects() -> object?[]!
 override XUnit3Helper.Models.TestData<TP1, TP2>.GetTheoryDataRow() -> Xunit.ITheoryDataRow!
 override XUnit3Helper.Models.TestData<TP1>.GetObjects() -> object?[]!
 override XUnit3Helper.Models.TestData<TP1>.GetTheoryDataRow() -> Xunit.ITheoryDataRow!
-static XUnit3Helper.Extensions.MockExtension.AddMocks(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, params System.Type![]! types) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static XUnit3Helper.Extensions.MockExtension.AddMocks(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, params System.Collections.Generic.IEnumerable<System.Type!>! types) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 XUnit3Helper.Extensions.MockExtension
 XUnit3Helper.Impl.CustomAutoDataAttribute
 XUnit3Helper.Impl.CustomAutoDataAttribute.CustomAutoDataAttribute() -> void
@@ -43,272 +43,272 @@ XUnit3Helper.Impl.JsonFileDataAttribute.JsonFileDataAttribute(string! filePath, 
 XUnit3Helper.Models.BaseTestData
 XUnit3Helper.Models.BaseTestData.BaseTestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P10.get -> TP10
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P10.get -> TP10?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P10.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P11.get -> TP11
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P11.get -> TP11?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P11.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P12.get -> TP12
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P12.get -> TP12?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P12.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P13.get -> TP13
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P13.get -> TP13?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P13.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P14.get -> TP14
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P14.get -> TP14?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P14.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P15.get -> TP15
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P15.get -> TP15?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P15.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P7.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P8.get -> TP8
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P8.get -> TP8?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P8.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P9.get -> TP9
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P9.get -> TP9?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.P9.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14, TP15>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P10.get -> TP10
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P10.get -> TP10?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P10.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P11.get -> TP11
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P11.get -> TP11?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P11.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P12.get -> TP12
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P12.get -> TP12?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P12.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P13.get -> TP13
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P13.get -> TP13?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P13.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P14.get -> TP14
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P14.get -> TP14?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P14.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P7.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P8.get -> TP8
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P8.get -> TP8?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P8.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P9.get -> TP9
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P9.get -> TP9?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.P9.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13, TP14>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P10.get -> TP10
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P10.get -> TP10?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P10.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P11.get -> TP11
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P11.get -> TP11?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P11.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P12.get -> TP12
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P12.get -> TP12?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P12.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P13.get -> TP13
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P13.get -> TP13?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P13.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P7.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P8.get -> TP8
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P8.get -> TP8?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P8.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P9.get -> TP9
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P9.get -> TP9?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.P9.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12, TP13>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P10.get -> TP10
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P10.get -> TP10?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P10.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P11.get -> TP11
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P11.get -> TP11?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P11.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P12.get -> TP12
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P12.get -> TP12?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P12.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P7.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P8.get -> TP8
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P8.get -> TP8?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P8.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P9.get -> TP9
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P9.get -> TP9?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.P9.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11, TP12>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P10.get -> TP10
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P10.get -> TP10?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P10.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P11.get -> TP11
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P11.get -> TP11?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P11.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P7.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P8.get -> TP8
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P8.get -> TP8?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P8.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P9.get -> TP9
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P9.get -> TP9?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.P9.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10, TP11>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P10.get -> TP10
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P10.get -> TP10?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P10.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P7.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P8.get -> TP8
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P8.get -> TP8?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P8.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P9.get -> TP9
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P9.get -> TP9?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.P9.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9, TP10>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P7.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P8.get -> TP8
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P8.get -> TP8?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P8.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P9.get -> TP9
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P9.get -> TP9?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.P9.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8, TP9>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P7.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P8.get -> TP8
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P8.get -> TP8?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.P8.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7, TP8>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P6.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P7.get -> TP7
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P7.get -> TP7?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.P7.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6, TP7>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P5.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P6.get -> TP6
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P6.get -> TP6?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.P6.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5, TP6>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P4.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P5.get -> TP5
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P5.get -> TP5?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.P5.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4, TP5>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P3.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P4.get -> TP4
+XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P4.get -> TP4?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.P4.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3, TP4>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3>
-XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P2.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P3.get -> TP3
+XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P3.get -> TP3?
 XUnit3Helper.Models.TestData<TP1, TP2, TP3>.P3.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2, TP3>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1, TP2>
-XUnit3Helper.Models.TestData<TP1, TP2>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1, TP2>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1, TP2>.P1.init -> void
-XUnit3Helper.Models.TestData<TP1, TP2>.P2.get -> TP2
+XUnit3Helper.Models.TestData<TP1, TP2>.P2.get -> TP2?
 XUnit3Helper.Models.TestData<TP1, TP2>.P2.init -> void
 XUnit3Helper.Models.TestData<TP1, TP2>.TestData() -> void
 XUnit3Helper.Models.TestData<TP1>
-XUnit3Helper.Models.TestData<TP1>.P1.get -> TP1
+XUnit3Helper.Models.TestData<TP1>.P1.get -> TP1?
 XUnit3Helper.Models.TestData<TP1>.P1.init -> void
 XUnit3Helper.Models.TestData<TP1>.TestData() -> void

--- a/tests/XUnit3Helper.Tests/Extensions/MockExtensionsTests.cs
+++ b/tests/XUnit3Helper.Tests/Extensions/MockExtensionsTests.cs
@@ -22,11 +22,12 @@ public sealed class MockExtensionsTests
         services.AddMocks(typeof(IClientProxy));
 
         using var serviceProvider = services.BuildServiceProvider();
-
-        _ = serviceProvider.GetRequiredService<Mock<IClientProxy>>();
-        _ = serviceProvider.GetRequiredService<IClientProxy>();
-
         Assert.Equal(2, services.Count);
+
+        var clientProxyMock = serviceProvider.GetRequiredService<Mock<IClientProxy>>();
+        var clientProxy = serviceProvider.GetRequiredService<IClientProxy>();
+
+        Assert.Same(clientProxyMock.Object, clientProxy);
     }
 
     [Theory, CustomAutoData]


### PR DESCRIPTION
Обновлены свойства классов `TestData` для использования nullable-типов (`TP1?`, `TP2?`, ..., `TPN?`), что позволяет обрабатывать необязательные значения. Методы `GetTheoryDataRow` и `GetObjects` также обновлены для работы с nullable-типами.

Обновлен публичный API в `PublicAPI.Unshipped.txt` для отражения этих изменений.

В тестах `MockExtensionsTests` улучшена читаемость и точность проверок. Метод `AddMocks` теперь принимает `IEnumerable<System.Type>` вместо массива `System.Type[]`.