### PR TITLE
fix Json file data logic

### DIFF
--- a/src/XUnit3Helper/Impl/JsonFileDataAttribute.cs
+++ b/src/XUnit3Helper/Impl/JsonFileDataAttribute.cs
@@ -21,7 +21,7 @@ public sealed class JsonFileDataAttribute(
 
         var parameters = testMethod.GetParameters();
         var parameterTypes = parameters.Select(x => x.ParameterType).ToArray();
-        if (parameterTypes.Length is 0 || simpleTypeJson && parameterTypes.Length > 15)
+        if (parameterTypes.Length is 0 || (!simpleTypeJson && parameterTypes.Length > 15))
         {
             throw new ArgumentException($"parameterTypes should be > 0 and < 15: {parameterTypes}");
         }


### PR DESCRIPTION
Обновлено условие проверки длины массива `parameterTypes` и флага `simpleTypeJson`. Теперь условие корректно обрабатывает случаи, когда `simpleTypeJson` ложно и длина массива превышает 15. Это изменение устраняет потенциальную ошибку и улучшает обработку входных данных.
