### PR TITLE
Обновление версий зависимостей

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Refit" Version="8.0.0" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
+    <PackageVersion Include="Refit" Version="9.0.2" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="9.0.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="ErrorOr" Version="2.0.1" />
@@ -37,7 +37,7 @@
     <PackageVersion Include="Riok.Mapperly" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.1-dev-02307" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
   <ItemGroup>
@@ -45,9 +45,9 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="xunit.v3" Version="3.2.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.analyzers" Version="1.25.0" />
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.26.0" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Обновлены следующие пакеты:
- `Refit` и `Refit.HttpClientFactory` с `8.0.0` до `9.0.2`.
- `Serilog.Extensions.Hosting` с `9.0.1-dev-02307` до `10.0.0`.
- `xunit.v3` с `3.2.0` до `3.2.1`.
- `xunit.analyzers` с `1.25.0` до `1.26.0`.
- `xunit.v3.extensibility.core` с `3.2.0` до `3.2.1`.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
